### PR TITLE
Documentation and Tests Review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 .test_durations
 yarn-error.log 
 .env
+.vscode/

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You will need [yarn](https://yarnpkg.com/lang/en/docs/install/) installed.
 It is recommended to use a Python virtual environment.
 
 ```bash
-git clone https://github.com/yearn/yearn-vaults
-cd yearn-vaults
+git clone https://github.com/Badger-Finance/badger-vaults
+cd badger-vaults
 yarn install --lock-file
 ```
 
@@ -94,8 +94,8 @@ Any command `in code blocks` is meant to be executed from a Mac/Linux terminal o
 11. Close & re-open your terminal before proceeding (to get the new environment variable values)
 12. If you don't have git yet, go [set it up](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/set-up-git)
 13. Pull the repository from GitHub and install its dependencies
-    - `git clone https://github.com/yearn/yearn-vaults`
-    - `cd yearn-vaults`
+    - `git clone https://github.com/Badger-Finance/badger-vaults`
+    - `cd badger-vaults`
     - `yarn install --lock-file`
       - You may have to install with `--ignore-engines` (try this if you get an error)
 14. Compile the Smart Contracts:

--- a/contracts/BadgerRegistry.sol
+++ b/contracts/BadgerRegistry.sol
@@ -100,9 +100,9 @@ contract BadgerRegistry {
 
     address pendingGovernance; // If this is non zero, this is an attack from the deployer
     address governance;
+    address rewards;
     address guardian;
     address management;
-    address rewards;
 
     StratInfo[] strategies;
   }

--- a/contracts/BadgerRegistry.sol
+++ b/contracts/BadgerRegistry.sol
@@ -111,16 +111,18 @@ contract BadgerRegistry {
 
   /// Anyone can add a vault to here, it will be indexed by their address
   function add(address vault) public {
-    vaults[msg.sender].add(vault);
-    
-    emit NewVault(msg.sender, vault);
+    bool added = vaults[msg.sender].add(vault);
+    if (added) { 
+      emit NewVault(msg.sender, vault);
+    }
   }
 
   /// Remove the vault from your index
   function remove(address vault) public {
-    vaults[msg.sender].remove(vault);
-
-    emit RemoveVault(msg.sender, vault);
+    bool removed = vaults[msg.sender].remove(vault);
+    if (removed) { 
+      emit RemoveVault(msg.sender, vault); 
+     }
   }
 
   //@dev Retrieve a list of all Vault Addresses from the given author
@@ -228,8 +230,10 @@ contract BadgerRegistry {
   //@dev Promote just means indexed by the Governance Address
   function promote(address vault) public {
     require(msg.sender == GOVERNANCE, "!gov");
-    vaults[msg.sender].add(vault);
+    bool promoted = vaults[msg.sender].add(vault);
 
-    emit PromoteVault(msg.sender, vault);
+    if (promoted) { 
+      emit PromoteVault(msg.sender, vault);
+    }
   }
 }

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -319,7 +319,7 @@ def initialize(
     self.DOMAIN_SEPARATOR = keccak256(
         concat(
             DOMAIN_TYPE_HASH,
-            keccak256(convert("Yearn Vault", Bytes[11])),
+            keccak256(convert("Badger Sett", Bytes[11])),
             keccak256(convert(API_VERSION, Bytes[28])),
             convert(chain.id, bytes32),
             convert(self, bytes32)

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract Token is ERC20 {
     mapping(address => bool) public _blocked;
 
-    constructor(uint8 _decimals) public ERC20("yearn.finance test token", "TEST") {
+    constructor(uint8 _decimals) public ERC20("badger.finance test token", "TEST") {
         _setupDecimals(_decimals);
         _mint(msg.sender, 30000 * 10**uint256(_decimals));
     }
@@ -43,7 +43,7 @@ contract TokenNoReturn {
     mapping(address => bool) public _blocked;
 
     constructor(uint8 _decimals) public {
-        name = "yearn.finance test token";
+        name = "badger.finance test token";
         symbol = "TEST";
         decimals = _decimals;
         balanceOf[msg.sender] = 30000 * 10**uint256(_decimals);

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -120,3 +120,7 @@ def rando(accounts):
 @pytest.fixture
 def registry(gov, Registry):
     yield gov.deploy(Registry)
+
+@pytest.fixture
+def badgerRegistry(gov, BadgerRegistry):
+    yield gov.deploy(BadgerRegistry)

--- a/tests/functional/registry/test_badger_registry.py
+++ b/tests/functional/registry/test_badger_registry.py
@@ -1,0 +1,151 @@
+import brownie
+from brownie import ZERO_ADDRESS, accounts
+
+def test_user_can_add_remove_vault(badgerRegistry, vault, rando, gov):
+    # Author adds vault to their list
+    tx = badgerRegistry.add(vault.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault.address]
+
+    event = tx.events["NewVault"][0]
+    assert event["vault"] == vault.address
+
+    # Same vault cannot be added twice (nothing happens)
+    tx = badgerRegistry.add(vault.address, {"from": rando})
+    assert len(tx.events) == 0
+
+    # Only author can remove vault from their list (nothing happens)
+    tx = badgerRegistry.remove(vault.address, {"from": gov})
+    assert len(tx.events) == 0
+    
+
+    # Author attempts to remove vault with address not on list (nothing happens)
+    tx = badgerRegistry.remove(ZERO_ADDRESS, {"from": gov})
+    assert len(tx.events) == 0
+
+    # Author can remove their own vault from list
+    tx = badgerRegistry.remove(vault.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == []
+
+    event = tx.events["RemoveVault"][0]
+    assert event["vault"] == vault.address
+
+
+
+def test_user_can_add_remove_multiple_vaults(badgerRegistry, create_vault, create_token, rando):
+    # Author creates and adds vault1 to registry
+    token1 = create_token()
+    vault1 = create_vault(token1, version="1.0.0")
+
+    badgerRegistry.add(vault1.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault1.address]
+
+    # Author creates and adds vault2 to registry
+    token2 = create_token()
+    vault2 = create_vault(token2, version="1.0.0")
+
+    badgerRegistry.add(vault2.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault1.address, vault2.address]
+
+    # Author creates and adds vault3 to registry
+    token3 = create_token()
+    vault3 = create_vault(token3, version="1.0.0")
+
+    badgerRegistry.add(vault3.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault1.address, vault2.address, vault3.address]
+
+    # Author can remove their own vault from list
+    tx = badgerRegistry.remove(vault1.address, {"from": rando})
+    event = tx.events["RemoveVault"][0]
+    assert event["vault"] == vault1.address
+    
+    # NOTE: Order of entries change when vaults are removed from sets
+    assert badgerRegistry.fromAuthor(rando.address) == [vault3.address, vault2.address]
+
+
+
+def test_view_functions(badgerRegistry, vault, strategy, rando):
+    badgerRegistry.add(vault.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault.address]
+
+    assert badgerRegistry.fromAuthorVaults(rando.address) == [
+        [
+            vault.address, 
+            vault.name(), 
+            vault.symbol(), 
+            vault.token(), 
+            vault.pendingGovernance(),
+            vault.governance(),
+            vault.rewards(),
+            vault.guardian(),
+            vault.management(),
+            [],
+        ],
+    ]
+
+    
+    # The return value matches the expected but Brownie cannot handle parsing the Strategy name
+    # due to the float values contained on it. To test, remove the appended apiVersion() from 
+    # TestStrategy's name() function.
+
+    # TODO: Adapt assertion to support comparison of strings containing floats
+
+    # params = vault.strategies(strategy.address)
+
+    # assert badgerRegistry.fromAuthorWithDetails(rando.address) == [
+    #     [
+    #         vault.address, 
+    #         vault.name(), 
+    #         vault.symbol(), 
+    #         vault.token(), 
+    #         vault.pendingGovernance(),
+    #         vault.governance(),
+    #         vault.rewards(),
+    #         vault.guardian(),
+    #         vault.management(),
+    #         [
+    #             [
+    #                 strategy.address,
+    #                 strategy.name(),
+    #                 strategy.strategist(),
+    #                 strategy.rewards(),
+    #                 strategy.keeper(),
+    #                 params[0], # performanceFee,
+    #                 params[1], # activation,
+    #                 params[2], # debtRatio,
+    #                 params[3], # minDebtPerHarvest,
+    #                 params[4], # maxDebtPerHarvest,
+    #                 params[5], # lastReport,
+    #                 params[6], # totalDebt,
+    #                 params[7], # totalGain,
+    #                 params[8], # totalLoss,
+    #                 params[9], # enforceChangeLimit,
+    #                 params[10], # profitLimitRatio,
+    #                 params[11], # lossLimitRatio,
+    #                 params[12], # customCheck
+    #             ],
+    #         ],
+    #     ],
+    # ]
+
+
+def test_vault_promotion(badgerRegistry, vault, rando):
+    governance = accounts.at("0xB65cef03b9B89f99517643226d76e286ee999e77", force=True)
+
+    # Author adds vault to their list
+    badgerRegistry.add(vault.address, {"from": rando})
+    assert badgerRegistry.fromAuthor(rando.address) == [vault.address]
+
+    # Random user attempts to promote vault and reverts
+    with brownie.reverts():
+        badgerRegistry.promote(vault.address, {"from": rando})
+
+    # Governance is able to promote vault
+    tx = badgerRegistry.promote(vault.address, {"from": governance})
+    assert badgerRegistry.fromAuthor(governance.address) == [vault.address]
+
+    event = tx.events["PromoteVault"][0]
+    assert event["vault"] == vault.address
+
+    # Same vault cannot be promoted twice (nothing happens)
+    tx = badgerRegistry.promote(vault.address, {"from": governance})
+    assert len(tx.events) == 0

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -25,8 +25,8 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
         token,
         gov,
         rewards,
-        token.symbol() + " yVault",
-        "yv" + token.symbol(),
+        "",
+        "",
         guardian,
     )
     # Addresses
@@ -36,8 +36,8 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.rewards() == rewards
     assert vault.token() == token
     # UI Stuff
-    assert vault.name() == token.symbol() + " yVault"
-    assert vault.symbol() == "yv" + token.symbol()
+    assert vault.name() == "Badger Sett " + token.symbol()
+    assert vault.symbol() == "b" + token.symbol()
     assert vault.decimals() == token.decimals()
     assert vault.apiVersion() == PACKAGE_VERSION
 
@@ -53,18 +53,18 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
 def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):
     # Deploy the Vault with name/symbol overrides
     vault = guardian.deploy(Vault)
-    vault.initialize(token, gov, rewards, "crvY yVault", "yvcrvY", guardian)
+    vault.initialize(token, gov, rewards, "Badger Sett TEST", "bTEST", guardian)
     # Assert that the overrides worked
-    assert vault.name() == "crvY yVault"
-    assert vault.symbol() == "yvcrvY"
+    assert vault.name() == "Badger Sett TEST"
+    assert vault.symbol() == "bTEST"
 
 
 def test_vault_reinitialization(guardian, gov, rewards, token, Vault):
     vault = guardian.deploy(Vault)
-    vault.initialize(token, gov, rewards, "crvY yVault", "yvcrvY", guardian)
+    vault.initialize(token, gov, rewards, "Badger Sett TEST", "bTEST", guardian)
     # Can't reinitialize a vault
     with brownie.reverts():
-        vault.initialize(token, gov, rewards, "crvY yVault", "yvcrvY", guardian)
+        vault.initialize(token, gov, rewards, "Badger Sett TEST", "bTEST", guardian)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR contains a few small fixes to the documentation, test suite and smart contracts. The following fixes are included:

- README.md: Git instructions were adapted to clone badger-vault repo instead of yearn's.
- BadgerRegistry.sol: add(), remove() and promote() functions were adapted to handle failure to perform the respective set interaction. Also, the `VaultInfo` struct's order of variables was fixed to match its implementation.
- Vault.py: The `DOMAIN_SEPARATOR` encoding was adapted to include `Badger Sett` instead of `Yearn Vault`.
- Token.sol: The token name was changed from using yearn to using Badger.
- A few tests were adapted to use Badger's name instead of Yearn's. A test to assess the init of a vault without an specific name was adapted to properly check for this.
- The `test_badger_registry.py` test suite was added.